### PR TITLE
Update Item Creator to work with new Item Slots

### DIFF
--- a/src/components/Contributor Tools/ItemFullView.vue
+++ b/src/components/Contributor Tools/ItemFullView.vue
@@ -274,6 +274,7 @@
 												:items="equipmentSlots"
 												v-model="item.equipmentProperties.slot"
 												label="Equipment Slot"
+												multiple
 												:readonly="!allowEdit"
 											></v-select>
 										</v-col>
@@ -522,10 +523,11 @@
 		const options = [];
 
 		for (const slot in EquipmentSlots) {
+			if (slot == "primaryWeapon") continue;
 			if (Object.prototype.hasOwnProperty.call(EquipmentSlots, slot)) {
 				options.push({
-					title: slot,
-					value: EquipmentSlots[slot],
+					title: EquipmentSlots[slot].name,
+					value: EquipmentSlots[slot].key,
 				});
 			}
 		}

--- a/src/components/Contributor Tools/ItemFullView.vue
+++ b/src/components/Contributor Tools/ItemFullView.vue
@@ -153,14 +153,24 @@
 											<v-select :items="weaponTypes" v-model="item.weaponProperties.weaponType" label="Weapon Type" :readonly="!allowEdit"></v-select>
 										</v-col>
 										<v-col cols="3">
-											<v-select
+											<!-- <v-select
 												:items="weaponHandling"
 												item-title="title"
 												item-value="value"
 												v-model="item.weaponProperties.handling"
 												label="Handling"
 												:readonly="!allowEdit"
-											></v-select>
+											></v-select> -->
+											<v-text-field
+												v-model="item.weaponProperties.handling"
+												type="number"
+												:label="getWeaponHandlingPower()"
+												density="compact"
+												step="0.1"
+												:min="0.5"
+												:max="2"
+												:readonly="!allowEdit"
+											></v-text-field>
 										</v-col>
 										<v-col cols="3">
 											<v-checkbox
@@ -279,14 +289,13 @@
 											></v-select>
 										</v-col>
 										<v-col cols="3">
-											<v-select
-												:items="armorBonus"
-												item-title="title"
-												item-value="value"
+											<v-text-field
 												v-model="item.equipmentProperties.armorBonus"
-												label="Armour Bonus"
+												type="number"
+												:label="getArmorBonusPower()"
 												:readonly="!allowEdit"
-											></v-select>
+												density="compact"
+											></v-text-field>
 										</v-col>
 										<v-col cols="3">
 											<v-checkbox
@@ -449,6 +458,29 @@
 		}
 	}
 
+	function getArmorBonusPower(): string {
+		const bonus = props.item.equipmentProperties.armorBonus;
+		const slots = props.item.equipmentProperties.slot.length;
+
+		const score = bonus / slots;
+		if (score >= 0) return `Armor Bonus (Average)`;
+		if (score <= 1) return `Armor Bonus (Low)`;
+		if (score <= 2) return `Armor Bonus (Moderate)`;
+		if (score <= 3) return `Armor Bonus (High)`;
+		if (score >= 4) return `Armor Bonus (Very High)`;
+		else return "Armor Bonus (Extreme)";
+	}
+
+	function getWeaponHandlingPower(): string {
+		const handling = props.item.weaponProperties.handling;
+		if (handling <= 0.5) return `Handling (Terrible)`;
+		if (handling <= 0.75) return `Handling (Poor)`;
+		if (handling <= 1) return `Handling (Average)`;
+		if (handling <= 1.25) return `Handling (Good)`;
+		if (handling <= 1.5) return `Handling (Great)`;
+		else return `Handling (Extreme)`;
+	}
+
 	function saveNewItem() {
 		const a = helpers.aliasString.replace(" ", "").split(",");
 		props.item.aliases = a;
@@ -509,15 +541,11 @@
 		{ title: "Average", value: 1 },
 		{ title: "Good", value: 1.25 },
 		{ title: "Great", value: 1.5 },
+		{ title: "Custom", value: 1 },
 	];
 
 	//TODO provide different values based on type ie Torso should be highest
-	const armorBonus = [
-		{ title: "Average (None)", value: 0 },
-		{ title: "Low", value: 1 },
-		{ title: "Moderate", value: 2 },
-		{ title: "High", value: 3 },
-	];
+	const armorBonus = [{ title: "Average (None)", value: 0 }, { title: "Low", value: 1 }, { title: "Moderate", value: 2 }, { title: "High", value: 3 }, { title: "Custom" }];
 
 	const equipmentSlots = computed(() => {
 		const options = [];

--- a/src/types/SwrpgTypes/Equipment.ts
+++ b/src/types/SwrpgTypes/Equipment.ts
@@ -6,17 +6,24 @@ export interface IDamageResistance {
 	value: number;
 }
 
-export enum EquipmentSlots {
-	Primary = "primary",
-	Head = "head",
-	Torso = "torso",
-	Legs = "legs",
-	// Arms,
-	Back = "back",
-}
+export type EquipmentSlot = "primaryWeapon" | "head" | "upperBody" | "lowerBody" | "back";
 
+export type EquipmentSlotConfig = {
+	key: EquipmentSlot;
+	name: string;
+	aliases?: string[];
+	displayOrder: number;
+};
+
+export const EquipmentSlots: Record<EquipmentSlot, EquipmentSlotConfig> = {
+	primaryWeapon: { key: "primaryWeapon", name: "Primary Weapon", displayOrder: 1, aliases: ["weapon"] },
+	head: { key: "head", name: "Head", displayOrder: 2, aliases: ["helmet", "headgear", "mask", "face", "hat"] },
+	upperBody: { key: "upperBody", name: "Upper Body", displayOrder: 3, aliases: ["gloves", "shirt", "torso", "upper", "chest", "top"] },
+	lowerBody: { key: "lowerBody", name: "Lower Body", displayOrder: 4, aliases: ["pants", "boots", "trousers", "legs", "greaves", "lower", "bottoms"] },
+	back: { key: "back", name: "Back", displayOrder: 5, aliases: ["backpack", "bag"] },
+};
 export interface IEquipmentProperties extends ISkillCappedItem {
-	slot: EquipmentSlots;
+	slot: EquipmentSlot[];
 	armorBonus: number;
 	resistances: IDamageResistance[];
 }
@@ -24,7 +31,7 @@ export interface IEquipmentProperties extends ISkillCappedItem {
 export function DEFUALT_EQUIPMENT(): IEquipmentProperties {
 	return {
 		armorBonus: 0,
-		slot: EquipmentSlots.Torso,
+		slot: [EquipmentSlots.upperBody.key],
 		resistances: [],
 		attributeRequirement: [],
 	};


### PR DESCRIPTION
# Changes
- Slot for equipment is now a multi select, saves value into array supporting the new format for slots
- Slots updated to use the same configuration as the new system. Exact same format, easy to update as slots change.
- Relative dropdown for Armor Bonus and Weapon Handling removed.
  - Now uses exact values. The Quality (i.e Terrible - Extreme) is shown in the tooltip. 
  - This allows finer grained control over the values.

## Ideas for future changes
- Implement the relative/score type system for 
  - Weight
  - Damage
    - Depending on Weapon Type
  - Value
    - Depending on Item Category