### PR TITLE
Added hook builder back to toolkit

### DIFF
--- a/src/components/Contributor Tools/ContributorSidebar.vue
+++ b/src/components/Contributor Tools/ContributorSidebar.vue
@@ -56,27 +56,27 @@ export default {
 						},
 					],
 				},
-				// {
-				// 	name: "GM Tools",
-				// 	isVisible: false,
-				// 	icon: "mdi-dice-d20",
-				// 	items: [
-				// 		{
-				// 			text: "Difficulty Checks",
-				// 			isVisible: true,
-				// 			click: function () {
-				// 				console.warn(`Not Implemented`);
-				// 			},
-				// 		},
-				// 		{
-				// 			text: "Hook Builder",
-				// 			isVisible: true,
-				// 			click: function () {
-				// 				console.warn(`Not Implemented`);
-				// 			},
-				// 		},
-				// 	],
-				// },
+				{
+					name: "GM Tools",
+					isVisible: true,
+					icon: "mdi-dice-d20",
+					items: [
+						{
+							text: "Difficulty Checks",
+							isVisible: false,
+							click: function () {
+								console.warn(`Not Implemented`);
+							},
+						},
+						{
+							text: "Hook Builder",
+							isVisible: true,
+							click: function () {
+								router.push({ path: "/tools/hook" });
+							},
+						},
+					],
+				},
 				{
 					name: "Package Creation",
 					isVisible: true,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,12 +1,15 @@
+import { createRouter, createWebHashHistory } from "vue-router";
+
+import ContentCreationVue from "@/views/Contributor Tools/Package Creation/AboutPackages.vue";
 import ContributorDirectoryVue from "@/views/Contributor Tools/ContributorDirectory.vue";
+import EventPackageCreator from "@/views/Contributor Tools/Package Creation/EventPackageCreator.vue";
+import HomeView from "@/views/HomeView.vue";
+import HookBuilder from "@/views/Contributor Tools/Tools/HookBuilder.vue";
+import ItemPackageCreatorVue from "@/views/Contributor Tools/Package Creation/ItemPackageCreator.vue";
 import ItemsDataSetVue from "@/views/Contributor Tools/Data Sets/ItemsDataSet.vue";
 import LocationDataSetVue from "@/views/Contributor Tools/Data Sets/LocationDataSet.vue";
-import ContentCreationVue from "@/views/Contributor Tools/Package Creation/AboutPackages.vue";
-import EventPackageCreator from "@/views/Contributor Tools/Package Creation/EventPackageCreator.vue";
-import ItemPackageCreatorVue from "@/views/Contributor Tools/Package Creation/ItemPackageCreator.vue";
 import LocationPackageCreator from "@/views/Contributor Tools/Package Creation/LocationPackageCreator.vue";
-import HomeView from "@/views/HomeView.vue";
-import { createRouter, createWebHashHistory } from "vue-router";
+
 const router = createRouter({
 	history: createWebHashHistory(),
 	routes: [
@@ -62,6 +65,28 @@ const router = createRouter({
 					name: "NPCs",
 					component: LocationDataSetVue, //async () => import("../views/Contributor Tools/ContentCreation.vue"),
 				},
+			],
+		},
+		{
+			path: "/tools",
+			name: "Tools",
+			component: ContributorDirectoryVue,
+			children: [
+				{
+					path: "hook",
+					name: "Hook Builder",
+					component: HookBuilder
+				},
+				// {
+				// 	path: "item",
+				// 	name: "Quest Item Builder",
+				// 	component: () => import("@/views/Tools/QuestItemCreator.vue"),
+				// },
+				// {
+				// 	path: "images",
+				// 	name: "Image Library",
+				// 	component: () => import("@/views/Tools/ImageLibrary.vue"),
+				// }
 			],
 		},
 	],

--- a/src/types/Hook.ts
+++ b/src/types/Hook.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
+export interface IHook {
+	title: string;
+	thumbnail: string | undefined;
+	image: string | undefined;
+	description: string;
+}
+
+export class Hook implements IHook {
+	title: string;
+	thumbnail: string;
+	image: string;
+	description: string;
+
+	constructor() {
+		this.title = "";
+		this.thumbnail = "";
+		this.image = "";
+		this.description = "";
+	}
+
+	toCommand(): string {
+		return `^!hook "${this.title}"${this.image.length > 0 ? ` --image=${this.image}` : ""}${this.thumbnail.length > 0 ? ` --thumbnail=${this.thumbnail}` : ""} "${this.description}"`;
+	}
+}

--- a/src/views/Contributor Tools/Tools/HookBuilder.vue
+++ b/src/views/Contributor Tools/Tools/HookBuilder.vue
@@ -1,0 +1,56 @@
+<template>
+	<v-col cols="5">
+		<v-card>
+			<v-card-title>Hook Builder</v-card-title>
+			<v-form class="pa-6 ma-2">
+				<v-text-field v-model="hook.title" label="Title" placeholder="Title"></v-text-field>
+				<v-textarea v-model="hook.description" label="Description" placeholder="Description"></v-textarea>
+				<v-text-field v-model="hook.thumbnail" label="Thumbnail URL (Optional)" placeholder="Image URL"></v-text-field>
+				<v-text-field v-model="hook.image" label="Image URL (Optional)" placeholder="Image URL"></v-text-field>
+
+				<v-row justify="space-around">
+					<discord-embed color="#121212" :title="hook.title" :thumbnail="hook.thumbnail" :image="hook.image">
+						<span v-if="hook.description">
+							{{ hook.description }}
+						</span>
+					</discord-embed>
+				</v-row>
+				<v-row justify="space-around" class="pa-4">
+					<v-btn color="success" dark v-on:click="copyToClipboard()" v-bind:disabled="hook.title.length == 0 || hook.description.length == 0">
+						Get Hook Code
+					</v-btn>
+					<v-btn color="primary" dark v-on:click="clearForm()">
+						Clear Form
+					</v-btn>
+				</v-row>
+			</v-form>
+			<v-snackbar v-model="snackbar" timeout="4000"> {{ hook.title }} was copied to clipboard </v-snackbar>
+		</v-card>
+	</v-col>
+</template>
+
+<script lang="ts">
+import DiscordEmbed from '@/components/Discord/DiscordEmbed.vue';
+import { Hook } from '@/types/Hook';
+import { defineComponent } from 'vue';
+
+    export default defineComponent({
+	name: "ContentCreation",
+    components: { DiscordEmbed },
+	methods: {
+		copyToClipboard() {
+			this.snackbar = true;
+			navigator.clipboard.writeText(this.hook.toCommand());
+		},
+		clearForm() {
+			this.hook = new Hook();
+		},
+	},
+	data: () => {
+		return {
+			hook: new Hook(),
+			snackbar: false,
+		};
+	},
+});
+</script>


### PR DESCRIPTION
<!--
::showcase
-->

I've now re-added the Hook Builder to the [SWRPG Toolkit](http://localhost:3030/#/tools/hook)

While it's really simple - it should make building the event hooks a lot simpler, and more attractive to use for GMs.

The Hook Builder means that GMs can effectively write embeds to introduce new or key moments in events, without having to manually write the command for them.

_Note this isn't optimized for mobile_

![image](https://github.com/Bejasc/swrpg-toolkit/assets/12091874/f7edbd6a-8f41-4dcf-a96f-51f9ea9fe4ce)

