### PR TITLE
Browse Event Image Library

### DIFF
--- a/src/components/Contributor Tools/ContributorSidebar.vue
+++ b/src/components/Contributor Tools/ContributorSidebar.vue
@@ -39,6 +39,14 @@ export default {
 					isVisible: true,
 					items: [
 						{
+							text: "Image Library",
+							isVisible: true,
+							icon: "mdi-image",
+							click: function () {
+								router.push({ path: "/data/event-images" });
+							},
+						},
+						{
 							text: "Items",
 							isVisible: true,
 							icon: "mdi-toolbox",
@@ -74,7 +82,7 @@ export default {
 							click: function () {
 								router.push({ path: "/tools/hook" });
 							},
-						},
+						}
 					],
 				},
 				{

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,7 @@ import ContributorDirectoryVue from "@/views/Contributor Tools/ContributorDirect
 import EventPackageCreator from "@/views/Contributor Tools/Package Creation/EventPackageCreator.vue";
 import HomeView from "@/views/HomeView.vue";
 import HookBuilder from "@/views/Contributor Tools/Tools/HookBuilder.vue";
+import ImageLibrary from "@/views/Contributor Tools/Data Sets/ImageLibrary.vue";
 import ItemPackageCreatorVue from "@/views/Contributor Tools/Package Creation/ItemPackageCreator.vue";
 import ItemsDataSetVue from "@/views/Contributor Tools/Data Sets/ItemsDataSet.vue";
 import LocationDataSetVue from "@/views/Contributor Tools/Data Sets/LocationDataSet.vue";
@@ -61,9 +62,9 @@ const router = createRouter({
 					component: ItemsDataSetVue, //async () => import("../views/Contributor Tools/ContentCreation.vue"),
 				},
 				{
-					path: "npcs",
-					name: "NPCs",
-					component: LocationDataSetVue, //async () => import("../views/Contributor Tools/ContentCreation.vue"),
+					path: "event-images",
+					name: "Image Library",
+					component: ImageLibrary, //async () => import("../views/Contributor Tools/ContentCreation.vue"),
 				},
 			],
 		},

--- a/src/views/Contributor Tools/Data Sets/ImageLibrary.vue
+++ b/src/views/Contributor Tools/Data Sets/ImageLibrary.vue
@@ -1,0 +1,111 @@
+<template>
+	<v-col cols="11">
+		<v-text-field dense v-model="search" clearable label="Search" prepend-inner-icon="mdi-magnify" single-line></v-text-field>
+		<v-row no-gutters style="max-height: 70vh" class="overflow-y-auto">
+			<v-col v-for="img in allImages" :key="img.url" cols="3">
+				<v-card class="ma-4">
+					<v-img class="imageMouseover" :src="img.url" :lazy-src="img.url" cover height="196px">
+
+					</v-img>
+				</v-card>
+			</v-col>
+		</v-row>
+	</v-col>
+</template>
+
+<style scoped>
+.imageMouseover {
+	filter: brightness(100%) blur(0.5px);
+	-webkit-transition: -webkit-filter 200ms linear;
+}
+.imageMouseover:hover {
+	cursor: pointer;
+
+	filter: brightness(115%) blur(0px);
+	-webkit-transition: -webkit-filter 200ms linear;
+}
+</style>
+
+<script setup lang="ts">
+import { all } from 'axios';
+import { Ref, computed, onMounted, ref } from 'vue';
+import { useStore } from 'vuex';
+
+const store = useStore();
+
+
+class ImageData {
+	public url:string;
+
+	public tags:string[] = [];
+	public metadata:Map<string,string> = new Map();
+
+	constructor(url:string){
+		this.url = url;
+	}
+}
+
+const search: Ref<string> = ref("");
+const allImages: Ref<ImageData[]> = ref();
+
+onMounted(async () => {
+	store.dispatch("showLoader", true);
+	allImages.value = await loadImages(20);
+	store.dispatch("showLoader", false);
+});
+
+async function loadImages(count:number):Promise<ImageData[]>{
+	//TODO actually iterate through Azure
+	const result:ImageData[] = [];
+	for(let i=0;i<count;i++){
+		const key = String(i+1).padStart(3,'0');
+		result.push(new ImageData(`https://cdn.bejasc.dev/swrpg/events/image${key}.png`))
+	}
+
+	return result;
+}
+
+</script>
+<!-- 
+<script lang="ts">
+import { getData } from "@/plugins/MongoConnector";
+import { ILocation } from "@/types/SwrpgTypes";
+import { defineComponent } from "vue";
+// Components
+export default defineComponent({
+	name: "ImageLibrary",
+	emits: ["pageNavigation"],
+	data: () => {
+		return {
+			search: "",
+			showLoader: false,
+			images: [] as string[],
+		};
+	},
+	mounted() {
+		this.$emit("pageNavigation", this.$route.name);
+
+		this.loadAllItems();
+	},
+	methods: {
+		async loadAllItems() {
+			this.$store.dispatch("showLoader", true);
+			this.locations = [];
+			this.locations = await getData<ILocation>("location");
+
+			console.table(this.locations);
+			this.$store.dispatch("showLoader", false);
+		},
+	},
+	computed: {
+		filteredItems(): ILocation[] {
+			return this.locations.filter((location: ILocation) => {
+				return location.name.toLowerCase().includes(this.search.toLowerCase()) || location.aliases?.some((e) => e.toLowerCase().includes(this.search.toLowerCase()));
+			});
+		},
+	},
+});
+</script> -->
+import { ILocation } from '@/types/SwrpgTypes';
+import { Ref, ref } from 'vue';
+

--- a/src/views/Contributor Tools/Tools/HookBuilder.vue
+++ b/src/views/Contributor Tools/Tools/HookBuilder.vue
@@ -24,7 +24,7 @@
 					</v-btn>
 				</v-row>
 			</v-form>
-			<v-snackbar v-model="snackbar" timeout="4000"> {{ hook.title }} was copied to clipboard </v-snackbar>
+			<v-snackbar v-model="snackbar" color="green" timeout="2500"> {{ hook.title }} was copied to clipboard </v-snackbar>
 		</v-card>
 	</v-col>
 </template>


### PR DESCRIPTION
Rudimentary ability to view all images stored in the Azure Blob Store, that can be served by the DRPG CDN.

Clicking on an image will open it for a larger preview, where the URL can be copied. Clicking on the background will also dismiss the preview.

The ability to filter, search and change the preview size will come at a later date.